### PR TITLE
Compile commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
-	g++ -fconcepts -fpermissive -mavx -std=c++20 -lSDL2 -lSDL2_image -lSDL2_ttf -lSDL2_gfx -lSDL2_mixer -O2 *.cpp -o main
+	clang++ -std=c++20 -lSDL2 -lSDL2_image -lSDL2_ttf -lSDL2_gfx -lSDL2_mixer -O2 *.cpp -o main -Wno-address-of-temporary -Wno-c++11-narrowing
 
 run: build
 	./main

--- a/Utils.cpp
+++ b/Utils.cpp
@@ -18,7 +18,7 @@ int modulo (int x, int y)
   return z;
 }
 
-V2 V2::operator + (const V2 other)
+V2 V2::operator + (const V2 other) const
 {
   return V2 { x + other.x, y + other.y };
 }

--- a/Utils.h
+++ b/Utils.h
@@ -17,7 +17,7 @@ struct V2
 {
   int x, y;
 
-  V2 operator + (const V2);
+  V2 operator + (const V2) const;
   V2 operator - (const V2);
 
   void operator += (const V2 other);

--- a/compilecommands
+++ b/compilecommands
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+tmp=$(cat Makefile | head -n 2 | tail -n 1 | cut -f 1 -d ' ' --complement)
+clang++ -MJ compile_commands.json $tmp > /dev/null 2>&1
+printf "[%s]" "$(cat compile_commands.json)" > compile_commands.json


### PR DESCRIPTION
gcc -> clang + fix compile error that clang didn't like.
We can use clang to generate the compile commands that ccls wants. Added script that does this.

Had to add `-Wno-address-of-temporary -Wno-c++11-narrowing` to bypass the errors clang raised, should probably look into these.